### PR TITLE
Use getWeekInfo() instead of weekInfo

### DIFF
--- a/src/utils/localeUtils.ts
+++ b/src/utils/localeUtils.ts
@@ -3,5 +3,5 @@ export function getLocale(): string {
 }
 
 export function getFirstDayOfWeek(): number {
-  return (new Intl.Locale(getLocale()) as any).weekInfo.firstDay;
+  return (new Intl.Locale(getLocale()) as any).getWeekInfo().firstDay;
 }


### PR DESCRIPTION
weekInfo is changed to getWeekInfo() in https://tc39.es/proposal-intl-locale-info/

See tc39/proposal-intl-locale-info#67